### PR TITLE
Fix typo in autoload path

### DIFF
--- a/addons/gdscript-interfaces/gdscript-interfaces.gd
+++ b/addons/gdscript-interfaces/gdscript-interfaces.gd
@@ -4,7 +4,7 @@ extends EditorPlugin
 const AUTOLOAD_NAME = "Interfaces"
 
 func _enter_tree() -> void:
-	add_autoload_singleton(AUTOLOAD_NAME, "res://addons/gdscript-interfaces/Interfaces.gd")
+	add_autoload_singleton(AUTOLOAD_NAME, "res://addons/gdscript-interfaces/interfaces.gd")
 
 
 func _exit_tree() -> void:


### PR DESCRIPTION
Attempts to resolve typo when adding interfaces.gd to the Autoload list.

Created by https://github.com/Mastermori/gdscript-interfaces/commit/e893283c47971deddc7907779b7fa0ba92672096.