### PR TITLE
Changed when Autoload is called

### DIFF
--- a/addons/gdscript-interfaces/gdscript-interfaces.gd
+++ b/addons/gdscript-interfaces/gdscript-interfaces.gd
@@ -3,9 +3,9 @@ extends EditorPlugin
 
 const AUTOLOAD_NAME = "Interfaces"
 
-func _enter_tree() -> void:
+func _enable_plugin() -> void:
 	add_autoload_singleton(AUTOLOAD_NAME, "res://addons/gdscript-interfaces/Interfaces.gd")
 
 
-func _exit_tree() -> void:
+func _disable_plugin() -> void:
 	remove_autoload_singleton(AUTOLOAD_NAME)


### PR DESCRIPTION
Changed from adding/removing the Autoload when the project is opened or closed to when the plugin is enabled or disabled.
This prevents the project setting from being rewritten every time, as those settings persist between editor sessions.